### PR TITLE
Add dockerfiles for building SDRR more easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ sdrr-hw-config/user/*
 !sdrr-hw-config/user/README.md
 config/user/*
 !config/user/README.md
+config/docker/*
+!config/docker/README.md
 images/users/*
 !images/user/README.md
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,9 +18,9 @@
     Recommended approach - download the toolchain from ARM's developer site (this is quite large, so may take a while):
 
     ```bash
-    wget https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
-    tar -xvf arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
-    sudo mv arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi /opt/
+    wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz
+    tar -xvf arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz
+    sudo mv arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi /opt/
     ```
 
     Or install it via your package manager, e.g., on Debian/Ubuntu:

--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,12 @@ ifneq ($(SUPPRESS_OUTPUT),1)
   $(info SDRR Makefile env settings:)
 endif
 
+ifneq ($(STM),)
+ifneq ($(SUPPRESS_OUTPUT),1)
+  $(info - STM=$(STM))
+endif
+endif
+
 ifneq ($(CONFIG),)
 ifneq ($(SUPPRESS_OUTPUT),1)
   $(info - CONFIG=$(CONFIG))

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -9,14 +9,6 @@ LABEL org.opencontainers.image.source="https://github.com/piersfinlayson/softwar
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.vendor="piers.rocks"
 
-# Build-time metadata
-ARG BUILD_DATE
-ARG VERSION
-ARG VCS_REF
-LABEL org.opencontainers.image.created=${BUILD_DATE}
-LABEL org.opencontainers.image.version=${VERSION}
-LABEL org.opencontainers.image.revision=${VCS_REF}
-
 # SDRR build args
 ARG CONFIG
 ARG STM
@@ -46,7 +38,8 @@ COPY config/docker/ /home/build/software-defined-retro-rom/config/docker/
 # Build SDRR
 WORKDIR /home/build/software-defined-retro-rom
 WORKDIR /home/build/software-defined-retro-rom
-RUN ${CONFIG:+CONFIG=$CONFIG} \
+RUN env \
+    ${CONFIG:+CONFIG=$CONFIG} \
     ${STM:+STM=$STM} \
     ${HW_REV:+HW_REV=$HW_REV} \
     ${ROM_CONFIGS:+ROM_CONFIGS="$ROM_CONFIGS"} \
@@ -73,7 +66,7 @@ RUN cp -r sdrr/build /home/build/output/
 
 # Output detailed firmware information
 RUN ELF_FILE=$(basename $(find sdrr/build -name "sdrr-stm32*.elf" -type f)) && \
-    /home/build/software-defined-retro-rom/rust/sdrr-info/target/release/sdrr-info info -d $ELF_FILE >> /home/build/output/sdrr-info.txt
+    /home/build/software-defined-retro-rom/rust/target/release/sdrr-info info -d /home/build/output/build/$ELF_FILE >> /home/build/output/sdrr-info.txt
 
 # Default to staying in the project directory
 WORKDIR /home/build/software-defined-retro-rom

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,80 @@
+FROM piersfinlayson/sdrr-build:latest
+
+# Metadata
+LABEL org.opencontainers.image.title="SDRR"
+LABEL org.opencontainers.image.description="Software Defined Retro ROM firmware and tools"
+LABEL org.opencontainers.image.authors="Piers Finlayson <piers@piers.rocks>"
+LABEL org.opencontainers.image.url="https://piers.rocks"
+LABEL org.opencontainers.image.source="https://github.com/piersfinlayson/software-defined-retro-rom"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="piers.rocks"
+
+# Build-time metadata
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+
+# SDRR build args
+ARG CONFIG
+ARG STM
+ARG HW_REV
+ARG ROM_CONFIGS
+ARG SWD
+ARG BOOT_LOGGING
+ARG MAIN_LOOP_LOGGING
+ARG MAIN_LOOP_ONE_SHOT
+ARG DEBUG_LOGGING
+ARG MCO
+ARG MCO2
+ARG OSC
+ARG FREQ
+ARG OVERCLOCK
+ARG STATUS_LED
+ARG BOOTLOADER
+ARG DISABLE_PRELOAD_TO_RAM
+ARG SERVE_ALG
+ARG GEN_OUTPUT_DIR
+ARG CARGO_PROFILE
+
+# Clone the repository
+RUN git clone https://github.com/piersfinlayson/software-defined-retro-rom.git
+COPY config/docker/ /home/build/software-defined-retro-rom/config/docker/
+
+# Build SDRR
+WORKDIR /home/build/software-defined-retro-rom
+WORKDIR /home/build/software-defined-retro-rom
+RUN ${CONFIG:+CONFIG=$CONFIG} \
+    ${STM:+STM=$STM} \
+    ${HW_REV:+HW_REV=$HW_REV} \
+    ${ROM_CONFIGS:+ROM_CONFIGS="$ROM_CONFIGS"} \
+    ${SWD:+SWD=$SWD} \
+    ${BOOT_LOGGING:+BOOT_LOGGING=$BOOT_LOGGING} \
+    ${MAIN_LOOP_LOGGING:+MAIN_LOOP_LOGGING=$MAIN_LOOP_LOGGING} \
+    ${MAIN_LOOP_ONE_SHOT:+MAIN_LOOP_ONE_SHOT=$MAIN_LOOP_ONE_SHOT} \
+    ${DEBUG_LOGGING:+DEBUG_LOGGING=$DEBUG_LOGGING} \
+    ${MCO:+MCO=$MCO} \
+    ${MCO2:+MCO2=$MCO2} \
+    ${OSC:+OSC=$OSC} \
+    ${FREQ:+FREQ=$FREQ} \
+    ${OVERCLOCK:+OVERCLOCK=$OVERCLOCK} \
+    ${STATUS_LED:+STATUS_LED=$STATUS_LED} \
+    ${BOOTLOADER:+BOOTLOADER=$BOOTLOADER} \
+    ${DISABLE_PRELOAD_TO_RAM:+DISABLE_PRELOAD_TO_RAM=$DISABLE_PRELOAD_TO_RAM} \
+    ${SERVE_ALG:+SERVE_ALG=$SERVE_ALG} \
+    ${GEN_OUTPUT_DIR:+GEN_OUTPUT_DIR=$GEN_OUTPUT_DIR} \
+    ${CARGO_PROFILE:+CARGO_PROFILE=$CARGO_PROFILE} \
+    make test info-detail
+
+# Copy build artifacts to output directory
+RUN cp -r sdrr/build /home/build/output/
+
+# Output detailed firmware information
+RUN ELF_FILE=$(basename $(find sdrr/build -name "sdrr-stm32*.elf" -type f)) && \
+    /home/build/software-defined-retro-rom/rust/sdrr-info/target/release/sdrr-info info -d $ELF_FILE >> /home/build/output/sdrr-info.txt
+
+# Default to staying in the project directory
+WORKDIR /home/build/software-defined-retro-rom
+VOLUME ["/home/build/output"]

--- a/ci/docker/Dockerfile.build
+++ b/ci/docker/Dockerfile.build
@@ -1,0 +1,77 @@
+FROM ubuntu:24.04
+
+# Metadata
+LABEL org.opencontainers.image.title="SDRR Build Environment"
+LABEL org.opencontainers.image.description="Multi-platform build environment for SDRR firmware and host tooling"
+LABEL org.opencontainers.image.authors="Piers Finlayson <piers@piers.rocks>"
+LABEL org.opencontainers.image.url="https://piers.rocks"
+LABEL org.opencontainers.image.source="https://github.com/piersfinlayson/software-defined-retro-rom"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="piers.rocks"
+
+# Build-time metadata (populated by CI/build scripts)
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+
+# Multiplatform support
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+# Install base dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    libcurl4-openssl-dev \
+    libjson-c-dev \
+    libzip-dev \
+    sudo \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download ARM toolchain based on target platform
+# See https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+ARG ARM_GCC_VERSION=14.2.rel1
+RUN case "${TARGETPLATFORM}" in \
+    "linux/amd64") \
+        ARCH_SUFFIX="x86_64" ;; \
+    "linux/arm64") \
+        ARCH_SUFFIX="aarch64" ;; \
+    "linux/arm/v7") \
+        ARCH_SUFFIX="x86_64" ;; \
+    *) \
+        echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac && \
+    wget https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_GCC_VERSION}/binrel/arm-gnu-toolchain-${ARM_GCC_VERSION}-${ARCH_SUFFIX}-arm-none-eabi.tar.xz && \
+    tar -xf arm-gnu-toolchain-${ARM_GCC_VERSION}-${ARCH_SUFFIX}-arm-none-eabi.tar.xz && \
+    mv arm-gnu-toolchain-${ARM_GCC_VERSION}-${ARCH_SUFFIX}-arm-none-eabi /opt/ && \
+    rm arm-gnu-toolchain-${ARM_GCC_VERSION}-${ARCH_SUFFIX}-arm-none-eabi.tar.xz && \
+    ln -s /opt/arm-gnu-toolchain-${ARM_GCC_VERSION}-${ARCH_SUFFIX}-arm-none-eabi /opt/arm-toolchain
+
+# Create build user
+RUN useradd -m -s /bin/bash build
+
+# Switch to build user
+USER build
+WORKDIR /home/build
+
+# Set TOOLCHAIN environment variable
+ENV TOOLCHAIN="/opt/arm-toolchain/bin"
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/build/.cargo/bin:${PATH}"
+
+# Install probe-rs
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/latest/download/probe-rs-tools-installer.sh | sh
+
+# Create output directory
+RUN mkdir -p /home/build/output
+
+WORKDIR /home/build
+VOLUME ["/home/build/output"]

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -11,7 +11,23 @@ Uses:
 * arm-gnu-toolchain-14.3.rel1-x86_64-arm-none
 * Latest Rust and probe-rs versions
 
-## `sdrr-build` Container
+## Building SDRR
+
+Either build via the [`sdrr` container](#building-sdrr-via-sdrr-container) or use the `sdrr-build` container directly, like this:
+
+```bash
+docker run --name sdrr-builder piersfinlayson/sdrr-build:latest sh -c '
+git clone https://github.com/piersfinlayson/software-defined-retro-rom.git && \
+cd software-defined-retro-rom && \
+STM=f401re HW_REV=24-f CONFIG=config/vic20-pal.mk make test info-detail
+'
+docker cp sdrr-builder:/home/build/software-defined-retro-rom/sdrr/build/sdrr-stm32f401re.elf /tmp/
+docker rm sdrr-builder
+```
+
+You can build additional configurations using the same container (i.e. not running `docker rm sdrr-builder`).  This avoids re-cloning the repo, and also avoids rebuilding all of the Rust tooling, which takes most of the build time.
+
+## Building `sdrr-build` Container
 
 To create the sdrr-build container, from the repo root:
 
@@ -25,15 +41,12 @@ docker buildx build \
     -f ci/docker/Dockerfile.build .
 ```
 
-## `sdrr` Container
+## Building SDRR via `sdrr` Container
 
 To build SDRR, create the sdrr container, from the repo root:
 
 ```bash
 docker build \
-    --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-    --build-arg VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev") \
-    --build-arg VCS_REF=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
     -f ci/docker/Dockerfile \
     -t piersfinlayson/sdrr:latest .
 ```
@@ -42,9 +55,6 @@ To use non-default build configuration, pass in build arguments.  For example:
 
 ```bash
 docker build \
-    --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-    --build-arg VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev") \
-    --build-arg VCS_REF=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
     --build-arg STM=f401re \
     --build-arg CONFIG=vic20-pal.mk \
     --build-arg HW_REV=24-f \

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -1,0 +1,53 @@
+# Docker
+
+This directory contains Dockerfiles for building the SDRR project in a consistent environment.
+
+* `Dockerfile.build` - creates `sdrr-build` container for building the SDRR project.
+* `Dockerfile` - creates `sdrr` tooling and firmware, using `sdrr-build` container.
+
+Uses:
+
+* Ubuntu 24.04
+* arm-gnu-toolchain-14.3.rel1-x86_64-arm-none
+* Latest Rust and probe-rs versions
+
+## `sdrr-build` Container
+
+To create the sdrr-build container, from the repo root:
+
+```bash
+docker buildx build \
+    --platform linux/amd64 \
+    --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    --build-arg VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev") \
+    --build-arg VCS_REF=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
+    -t piersfinlayson/sdrr-build:latest \
+    -f ci/docker/Dockerfile.build .
+```
+
+## `sdrr` Container
+
+To build SDRR, create the sdrr container, from the repo root:
+
+```bash
+docker build \
+    --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    --build-arg VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev") \
+    --build-arg VCS_REF=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
+    -f ci/docker/Dockerfile \
+    -t piersfinlayson/sdrr:latest .
+```
+
+To use non-default build configuration, pass in build arguments.  For example:
+
+```bash
+docker build \
+    --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    --build-arg VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev") \
+    --build-arg VCS_REF=$(git rev-parse HEAD 2>/dev/null || echo "unknown") \
+    --build-arg STM=f401re \
+    --build-arg CONFIG=vic20-pal.mk \
+    --build-arg HW_REV=24-f \
+    -f ci/docker/Dockerfile \
+    -t piersfinlayson/sdrr-f401re-24-f-vic20-pal:latest .
+```

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -1,0 +1,3 @@
+# Docker config
+
+Contains additional configuration files for preloading into the [SDRR container](/ci/docker/README.md#sdrr-container).

--- a/docs/BUILD-SYSTEM.md
+++ b/docs/BUILD-SYSTEM.md
@@ -101,7 +101,7 @@ Original ROM → Size Validation → Pin Mapping → Flash Layout → C Arrays
 **Toolchain Setup**:
 
 ```makefile
-TOOLCHAIN := /opt/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi
+TOOLCHAIN := /opt/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi
 CC := $(TOOLCHAIN)/bin/arm-none-eabi-gcc
 OBJCOPY := $(TOOLCHAIN)/bin/arm-none-eabi-objcopy
 ```

--- a/sdrr/Makefile
+++ b/sdrr/Makefile
@@ -24,7 +24,7 @@ endif
 BUILD_DIR := build
 
 # Toolchain
-TOOLCHAIN ?= /opt/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin
+TOOLCHAIN ?= /opt/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi/bin
 CC := $(TOOLCHAIN)/arm-none-eabi-gcc
 OBJDUMP := $(TOOLCHAIN)/arm-none-eabi-objdump
 OBJCOPY := $(TOOLCHAIN)/arm-none-eabi-objcopy


### PR DESCRIPTION
New:
- `Dockerfile.build` - creates a container with all of the build dependencies
- `Dockerfile` - creates SDRR firmware

Can use `Dockerfile` directly to create SDRR firmware, passing in config options as `--build-args` (e.g. `--build-arg HW_REV=24-f`) or you can use the container `piersfinlayson/sdrr-build:latest` to build the SDRR firmware directly.  See [`README`](ci/docker/README.md).