### PR TITLE
Adds dynamically bank switched ROMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notables changes between versions are documented in this file.
 - Moved firmware parsing to [`rust/sdrr-fw-parser`](/rust/sdrr-fw-parser/README.md) crate, which can be used to parse the firmware and extract information about the configuration, ROM images, and to extract ROM images from the firmware.  Done in preparation for using from a separate WiFi Programmer.
 - Moved Rust code to [`rust/`](/rust/) directory.
 - Added [build containers](/ci/docker/README.md) to assist with building SDRR, and doing so with the recommended build environment.
+- Added dynamic [bank switchable](docs/MULTI-ROM-SETS.md#dynamic-bank-switching) ROM image support, using X1/X2 (when not using multiple simultaneous ROMs).
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Emulates 2364, 2332 and 2316 ROMs using the STM32F4 family of microcontrollers. 
 - 🛠️ **Reflash in situ** - no need to remove the ROM from the host when reprogramming.
 - ⚙️ **Software configurable** chip select lines - no hardware jumpers required.
 - 💾 Stores up to **16 ROM images** of different sizes and chip select configurations.  Image selectable via jumpers.
-- 📦 One software ROM can **replace multiple ROMs** in a single system, e.g. all of C64 kernel, BASIC, character set.
+- 📦 **Replace multiple ROMs with one ROM** one SDRR can replace up to 3 original ROMs e.g. all of C64 kernel, BASIC, character set.
+- 🔀 **Dynamic bank switching** - switch between ROM images on the fly, e.g. different char ROMs.
 - 🧩 **Images combined automatically** - no need to manually build up your own larger PROM image containing multiple retro ROMs.
 - 🏭 **Two layer PCB**, component on single-side, limited BOM for low manufacturing cost/complexity.
 - 🎯 Supports multiple **STM32F4xxR** variants: F401, F411, F405, F446 (others can be added).
@@ -82,7 +83,7 @@ For configuration options, see [Configuration](docs/CONFIGURATION.md) and the [M
 - [Available Configurations](config/README.md#available-configurations) - Various pre-collated ROM collection configurations.
 - [STM32 Selection](docs/STM32-SELECTION.md) - How to select the appropriate STM32 variant for your application.
 - [Image Selection](docs/IMAGE-SELECTION.md) - How to tell SDRR which of the installed ROM images to serve.
-- [Multi-ROM Sets](docs/MULTI-ROM-SETS.md) - How to use a single SDRR to serve multiple ROMs simultaneously.
+- [Multi-ROM Sets](docs/MULTI-ROM-SETS.md) - How to use a single SDRR to support multiple ROMs simultaneously or to dynamically switch between images.
 - [Configuration](docs/CONFIGURATION.md) - SDRR configuration options.
 - [Logging](docs/LOGGING.md) - How to enable and use logging in SDRR.
 - [Technical Summary](docs/TECHNICAL-SUMMARY.md) - Overview of the SDRR architecture, operation and design decisions.

--- a/ci/blacklist-config.txt
+++ b/ci/blacklist-config.txt
@@ -12,3 +12,6 @@ c64
 set-c64
 set-vic20-pal
 set-1541
+bank-1541
+bank-c64-char
+bank-vic20-char

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -32,10 +32,14 @@ set -e  # Exit immediately on any command failure
 # Determine script and project directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-BLACKLIST_FILE="${SCRIPT_DIR}/blacklist-config.txt"
-STM_VARIANTS_FILE="${SCRIPT_DIR}/stm-variants.txt"
-SIZE_INCOMPATIBLE_FILE="${SCRIPT_DIR}/size-incompatible.txt"
-TESTS_FILE="${SCRIPT_DIR}/tests.txt"
+BLACKLIST_FILENAME="blacklist-config.txt"
+STM_VARIANTS_FILENAME="stm-variants.txt"
+SIZE_INCOMPATIBLE_FILENAME="size-incompatible.txt"
+TESTS_FILENAME="tests.txt"
+BLACKLIST_FILE="${SCRIPT_DIR}/${BLACKLIST_FILENAME}"
+STM_VARIANTS_FILE="${SCRIPT_DIR}/${STM_VARIANTS_FILENAME}"
+SIZE_INCOMPATIBLE_FILE="${SCRIPT_DIR}/${SIZE_INCOMPATIBLE_FILENAME}"
+TESTS_FILE="${SCRIPT_DIR}/${TESTS_FILENAME}"
 
 #
 # Display usage information and exit
@@ -49,10 +53,10 @@ usage() {
     echo "  clean             - Delete builds/ directory"
     echo ""
     echo "Configuration files:"
-    echo "  ${STM_VARIANTS_FILE}      - STM32 variants to build"
-    echo "  ${BLACKLIST_FILE}  - Configs to skip"
-    echo "  ${SIZE_INCOMPATIBLE_FILE} - Size-incompatible combinations"
-    echo "  ${TESTS_FILE}             - Specific test combinations"
+    echo "  ci/${STM_VARIANTS_FILENAME}      - STM32 variants to build"
+    echo "  ci/${BLACKLIST_FILENAME}  - Configs to skip"
+    echo "  ci/${SIZE_INCOMPATIBLE_FILENAME} - Size-incompatible combinations"
+    echo "  ci/${TESTS_FILENAME}             - Specific test combinations"
     exit 1
 }
 

--- a/ci/tests.txt
+++ b/ci/tests.txt
@@ -39,6 +39,9 @@ test-hw-rev-F:HW_REV=f,STM=f411re,CONFIG=config/test-sdrr-0.mk
 test-set-c64-f411re:HW_REV=24-f,STM=f411re,CONFIG=config/set-c64.mk
 test-set-vic20-pal-f411re:HW_REV=24-f,STM=f411re,CONFIG=config/set-vic20-pal.mk
 
+# Test each bank switching config
+bank-switching-f401rb:STM=f401rb,HW_REV=f,CONFIG=config/bank-1541.mk
+
 # Test different hardware revisions
 hw-rev-d:HW_REV=24-d,STM=f401rb,CONFIG=config/test-sdrr-0.mk
 hw-rev-e:HW_REV=24-e,STM=f401rb,CONFIG=config/test-sdrr-0.mk

--- a/ci/tests.txt
+++ b/ci/tests.txt
@@ -40,7 +40,9 @@ test-set-c64-f411re:HW_REV=24-f,STM=f411re,CONFIG=config/set-c64.mk
 test-set-vic20-pal-f411re:HW_REV=24-f,STM=f411re,CONFIG=config/set-vic20-pal.mk
 
 # Test each bank switching config
-bank-switching-f401rb:STM=f401rb,HW_REV=f,CONFIG=config/bank-1541.mk
+bank-1541-f405rg:STM=f405rg,HW_REV=f,CONFIG=config/bank-1541.mk
+bank-c64-char-f405rg:STM=f405rg,HW_REV=f,CONFIG=config/bank-c64-char.mk
+bank-vic20-char-f405rg:STM=f405rg,HW_REV=f,CONFIG=config/bank-vic20-char.mk
 
 # Test different hardware revisions
 hw-rev-d:HW_REV=24-d,STM=f401rb,CONFIG=config/test-sdrr-0.mk

--- a/config/bank-1541.mk
+++ b/config/bank-1541.mk
@@ -1,0 +1,16 @@
+# Contains stock dynamically bank switchable upper ($E000) kernal ROMs for the
+# 1540/1541 drives which use 8KB (2364) ROMs
+#
+# The second set contains just a single image - the lower ($C000) ROM 
+#
+# Images:
+# Set 0 - Bank 0 - 1541 $E000 8KB ROM, 901229-06AA
+# Set 0 - Bank 1 - 1541 $E000 8KB ROM, 901229-05
+# Set 0 - Bank 2 - 1541 $E000 8KB ROM, 325303-01
+# Set 1 - 1541/1540 $C000 8KB ROM, 325302-01
+
+ROM_CONFIGS = \
+	set=0,bank=0,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1541-e000.901229-06AA.bin,type=2364,cs1=0 \
+	set=0,bank=1,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1541-e000.901229-05.bin,type=2364,cs1=0 \
+	set=0,bank=2,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1540-e000.325303-01.bin,type=2364,cs1=0 \
+	set=1,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1541-c000.325302-01.bin,type=2364,cs1=0

--- a/config/bank-c64-char.mk
+++ b/config/bank-c64-char.mk
@@ -1,0 +1,21 @@
+# Contains dynamically bank switchable C64 character sets
+#
+# Images:
+# Set 0, Bank 0 - 4KB Character ROM, English, 901225-01
+# Set 0, Bank 1 - 4KB Character ROM, Swedish, 325018-02
+# Set 0, Bank 2 - 4KB Character ROM, Spanish, 325056-03
+# Set 0, Bank 3 - 4KB Character ROM, Danish, 901225-01-DK
+# Set 1, Bank 0 - 4KB Character ROM, English, 901225-01
+# Set 1, Bank 1 - 4KB Character ROM, Turkish
+# Set 1, Bank 2 - 4KB Character ROM, Croatian
+# Set 1, Bank 3 - 4KB Character ROM, Japanese, 906143-02
+
+ROM_CONFIGS = \
+	set=0,bank=0,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.901225-01.bin,type=2332,cs1=0,cs2=1 \
+	set=0,bank=1,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.325018-02.bin,type=2332,cs1=0,cs2=1 \
+	set=0,bank=2,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.325056-03.bin,type=2332,cs1=0,cs2=1 \
+	set=0,bank=3,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.901225-01-DK.bin,type=2332,cs1=0,cs2=1 \
+	set=1,bank=0,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.901225-01.bin,type=2332,cs1=0,cs2=1 \
+	set=1,bank=1,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.turkish.bin,type=2332,cs1=0,cs2=1 \
+	set=1,bank=2,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/croatian.zip,extract=c64_cro/chargen,type=2332,cs1=0,cs2=1 \
+	set=1,bank=3,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.906143-02.bin,type=2332,cs1=0,cs2=1

--- a/config/bank-vic20-char.mk
+++ b/config/bank-vic20-char.mk
@@ -1,0 +1,13 @@
+# Contains dynamically bank switchable VIC-20 character sets
+#
+# Images:
+# Set 0, Bank 0 - 4KB Character ROM, English, 901486-01
+# Set 0, Bank 1 - 4KB Character ROM, Swedish/Finnish, NEC P22101-207
+# Set 0, Bank 2 - 4KB Character ROM, Danish, 901460-03
+# Set 0, Bank 3 - 4KB Character ROM, Japanese, 901460-02
+
+ROM_CONFIGS = \
+	set=0,bank=0,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/vic20/characters.901460-03.bin,type=2332,cs1=0,cs2=0 \
+	set=0,bank=1,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/vic20/characters.NecP22101-207.bin,type=2332,cs1=0,cs2=0 \
+	set=0,bank=2,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/vic20/characters.DK_901460-03.bin,type=2332,cs1=0,cs2=0 \
+	set=0,bank=3,file=http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/vic20/characters.901460-02.bin,type=2332,cs1=0,cs2=0

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,6 +61,7 @@ key1=value1,key2=value2,...,command1,command2
 
 Supported key/value pairs are:
 
+- `set`: Optional.  Use for multi-ROMs sets, with multiple images in a set.  You need a line per image within the set, so multiple lines with the same `set` value.  If not specified, the image is in its own set.
 - `file`: Required.  The path to the ROM file to include in the firmware.  This can be a local file, or a URL.
 - `extract`: Optional.  Valid only if `file` is a URL, and the file to be downloaded is a ZIP file.  This specifies the path within the ZIP file to extract the ROM from.  Use URL encoding to encode any special characters in the path, such as spaces (%20).
 - `licence`: Optional.  URL to path for this ROM image's licence.  Including this causes the build process to force the user to explicitly acknowledge they accept the licence terms before the firmware is built.
@@ -134,4 +135,3 @@ B - Checks address lines only when CS is active, and applies to data lines (whic
 In all cases tested, `B` appears to be the superior algorithm, but `A` is kept in case it is incompatible with some systems.
 
 SDRR defaults to `B` is no algorithm is specified for single-ROM sets, and requires `B` (which is applies automatically, even if you specify `A`) for multi-ROM sets.
-

--- a/docs/CUSTOM-HARDWARE.md
+++ b/docs/CUSTOM-HARDWARE.md
@@ -10,6 +10,7 @@ If you are using an STM32F4xxR based system:
 
 - You **must** assign all of the address lines and chip select lines to Port C.
 - You **must** "right justify" the address and chip select lines, so they start at PC0, and use contiguous lines.
+- If you provide X1/X2 they **must** follow the address and CS lines, so be PC14/PC15.
 - You **must** assign the data lines to pins PA0-7 inclusive.
 
 With the above requirements, the address and chip select lines, and data lines, can be assigned to the specified range of pins in any order.  Address and CS lines can be mixed together.

--- a/docs/MULTI-ROM-SETS.md
+++ b/docs/MULTI-ROM-SETS.md
@@ -1,6 +1,24 @@
 # Multiple ROM Sets
 
-As of version v0.2.0, SDRR hardware revision F onwards supports multiple ROM image sets.  A set is a group of up to 3 ROM images, all of which SDRR will serve, so long as all of the following conditions are met:
+SDRR offers two models of run-time multi-ROM image support:
+
+- **Dynamic bank switched image sets**.  In this mode, the ROM images in a set can dynamically switched at runtime (requiring no SDRR or host reset).  This is done by using the X1 and X2 pins as bank select lines.
+
+- **Multiple simultaneous ROM image sets**.  A set is a group of up to 3 ROM images, all of which SDRR will serve **simultaneously**.  In this model, extra chip select lines from the extra ROM sockets to be served are connected to SDRR pins X1 and X2.  This allows one SDRR to serve up to 3 ROM images.  (Restrictions apply, see below.)
+
+## Dynamic Bank Switching
+
+Dynamic bank switching requires hardware revision F onwards, and firmware version v0.2.1 onwards.
+
+Dynamic bank switching supports all ROM types (2364, 2332 and 2316) with any CS configuration.
+
+In this mode, all ROMs in a particular set must share the same ROM type and CS configuration.the
+
+## Multiple Simultaneous ROM Image Sets
+
+Multiple simultaneous ROM image sets requires hardware revision E onwards, and firmware version v0.2.1 onwards.
+
+For this feature, the following conditions must be met:
 
 - All the ROMs being replaced share the same address and data buses.
 - SDRR is installed in the socket of the first ROM in the set to be replaced.
@@ -11,27 +29,64 @@ This feature is currently available only for 2364 ROMs, and 2332/2316 ROMs whose
 
 You can find pre-built configurations in [`config`](/config/README.md), named `set-*.mk`.
 
-It is recommended to have a (10%+) faster STM32F4 variant than standard speed test results documented in [STM32 Selection](/docs/STM32-SELECTION.md) suggest, as the serving algorithm for rom sets is slightly less efficient than for single ROM images.
+[STM32 Selection](/docs/STM32-SELECTION.md) gives guidance on the STM32F4 clock speed requirement for serving Multi-ROM sets.
 
 ## Set Configuration
 
-Under the covers, the code now always uses the concepts of sets, even if they are not specified - in this case, each ROM image is in its own set.  Hence the existing configuration model remains supported.
-
-To explicitly define sets, use a `ROM_CONFIGS` setting like this:
+Under the covers, the SDRR uses the concepts of sets, even if they are not specified - in this case, each ROM image is in its own set.  Hence the existing configuration model remains supported.  That single image set configuration looks like:
 
 ```Makefile
 ROM_CONFIGS = \
-	set=0,file=rom_2364_1.bin,type=2364,cs1=0 \
-	set=0,file=rom_2332_1.bin,type=2332,cs1=0,cs2=ignore \
-	set=0,file=rom_2364_1.bin,type=2364,cs1=0 \
-	set=1,file=rom_2364_3.bin,type=2364,cs1=0
+    file=rom_2364_1.bin,type=2364,cs1=0 \
+    file=rom_2332_1.bin,type=2332,cs1=0,cs2=0
+```
+
+That is still a perfectly valid approach, if you do not want multi-ROM sets, or dynamic bank switching.
+
+### Multi-ROM Set Configuration
+
+To define multi-ROM sets, in order to serve multiple ROM images simultaneously, use a `ROM_CONFIGS` setting like this:
+
+```Makefile
+ROM_CONFIGS = \
+    set=0,file=rom_2364_1.bin,type=2364,cs1=0 \
+    set=0,file=rom_2332_1.bin,type=2332,cs1=0,cs2=ignore \
+    set=0,file=rom_2364_2.bin,type=2364,cs1=0 \
+    set=1,file=rom_2364_3.bin,type=2364,cs1=0
 ```
 
 Each set can contain 1, 2 or 3 images, and are selected by the regular CS line, X1 and X2 respectively.  All CS1 values must be the same within a set - `sdrr-gen` attempts to detect and reject invalid configurations.
 
+In the example above, the first set (select if the regular image select jumpers are all open), the ROM will serve
+
+- `rom_2361_1.bin` to the socket it is installed in, if that socket's CS line goes active.
+- `rom_2332_1.bin` to the same data bus, if the CS line from socket 2 is connected to X1, when this cs line goes active.
+- `rom_2364_2.bin` to the same data bus, if the CS line from socket 3 is connected to X2, when this CS line goes active.
+
+### Dynamic Bank Switching Configuration
+
+To define dynamic bank switching, use a `ROM_CONFIGS` setting like this:
+
+```Makefile
+ROM_CONFIGS = \
+    set=0,bank=0,file=rom_2364_1.bin,type=2364,cs1=0
+    set=0,bank=1,file=rom_2364_2.bin,type=2364,cs1=0
+    set=0,bank=2,file=rom_2364_3.bin,type=2364,cs1=0
+    set=1,filename=rom2364_5.bin,type=2364,cs1=0
+```
+
+Here, when set 0 is selected, by all the image select jumpers being open, the ROM within that set that is served is selected by using X1 and X2 as image select jumpers.
+
+- X1/X2 open - `rom_2364_1.bin` is served
+- X1 closed/X2 open - `rom_2364_2.bin` is served
+- X1 open/X2 closed - `rom_2364_3.bin` is served
+- X1/X2 closed - `rom_2364_1.bin` is served
+
+The last line takes some explaining.  As only 3 banks are configured, images 0-2 exist.  However, bank 3 has been selected by closing both X1 and X2.  SDRR takes the bank select **modulo** the number of images (i.e. wraps and starts counting again), so reverts to image 0.
+
 ## Future Enhancements
 
-### 2332s With Varying CS2
+### Multi-ROM sets: 2332s With Varying CS2
 
 It should be possible to support a set of 2332 ROMs with CS2 varying, so long as all of the chips being replaced share the same CS2 line (i.e. are connected together).  The serving algorithm to implement this may be less efficient again than the stock mutli-rom set serving algorithm, but it is likely to be required by less powerful machines, so this is unlikely to be an issue.
 
@@ -42,6 +97,8 @@ It may also be possible to support combined 2332/2316 sets, so long as CS2 on th
 ## Technical Details
 
 In order to implemented this feature, all ROM images in the set are combined into a single 64KB image before storing into the firmware, and then the entirety of the STM32 port C GPIO state is read as an offset into that image. The ROM images are placed in the correct place for this lookup to work by the pre-processing step, using `sdrr-gen`.
+
+### Multi-ROM Set Serving Details
 
 If only 2 ROM images are in the set, the final bit of port C (PC15) is expected to be unconnected, and pulled low internally, just as when serving a single ROM image, PC14/PC15 are both pulled low, to ensure a 16KB offset into a 16KB image.  A 64Kb image is still used in the 2 ROM images in a set case, although a future enhancement could reduce the space required to 32KB.
 
@@ -54,6 +111,10 @@ It is this different algorithm that is roughly 10% less efficient than the singl
 
 See [Multi-ROM Support](/docs/TECHNICAL-SUMMARY.md#multi-rom-support) for more details on the performance on this feature.
 
+### Dynamic Bank Switching Serving Details
+
+In this case, again, 64Kb is used for the total ROM image, and X1/X2 act as an index into that.  The total ROM image is created differently than in the multi-ROM set case, as the two cases vary in which byte should be returned given the precise CS/X1/X2 states.
+
 ## Acknowledgements
 
-Original suggestion of this enhancement was made by [Adrian Black](https://www.youtube.com/@adriansdigitalbasement).
+Original suggestion of Multi-ROM sets was made by [Adrian Black](https://www.youtube.com/@adriansdigitalbasement).

--- a/rust/sdrr-common/src/args.rs
+++ b/rust/sdrr-common/src/args.rs
@@ -2,8 +2,8 @@
 //
 // MIT License
 
-use crate::hardware::{get_hw_config, HwConfig};
-use crate::sdrr_types::{StmVariant, ServeAlg};
+use crate::hardware::{HwConfig, get_hw_config};
+use crate::sdrr_types::{ServeAlg, StmVariant};
 
 pub fn parse_stm_variant(s: &str) -> Result<StmVariant, String> {
     StmVariant::from_str(s)
@@ -19,8 +19,12 @@ pub fn parse_hw_rev(hw_rev: &str) -> Result<HwConfig, String> {
         _ => hw_rev,
     };
 
-    let hw_config = get_hw_config(hw_rev)
-        .map_err(|e| format!("Failed to get hardware config: {} - use --list-hw-revs for options", e))?;
+    let hw_config = get_hw_config(hw_rev).map_err(|e| {
+        format!(
+            "Failed to get hardware config: {} - use --list-hw-revs for options",
+            e
+        )
+    })?;
 
     if hw_config.rom.pins.quantity != 24 {
         return Err(format!(
@@ -28,7 +32,7 @@ pub fn parse_hw_rev(hw_rev: &str) -> Result<HwConfig, String> {
             hw_rev, hw_config.rom.pins.quantity
         ));
     }
-    
+
     Ok(hw_config)
 }
 
@@ -40,4 +44,3 @@ pub fn parse_serve_alg(s: &str) -> Result<ServeAlg, String> {
         )
     })
 }
-

--- a/rust/sdrr-common/src/lib.rs
+++ b/rust/sdrr-common/src/lib.rs
@@ -2,6 +2,6 @@
 //
 // MIT License
 
-pub mod sdrr_types;
-pub mod hardware;
 pub mod args;
+pub mod hardware;
+pub mod sdrr_types;

--- a/rust/sdrr-common/src/sdrr_types.rs
+++ b/rust/sdrr-common/src/sdrr_types.rs
@@ -25,18 +25,18 @@ impl RomType {
 
     pub fn num_addr_lines(&self) -> usize {
         match self {
-            RomType::Rom2316 => 11, // 2^11 = 2048 bytes
-            RomType::Rom2332 => 12, // 2^12 = 4096 bytes
-            RomType::Rom2364 => 13, // 2^13 = 8192 bytes
+            RomType::Rom2316 => 11,  // 2^11 = 2048 bytes
+            RomType::Rom2332 => 12,  // 2^12 = 4096 bytes
+            RomType::Rom2364 => 13,  // 2^13 = 8192 bytes
             RomType::Rom23128 => 14, // 2^14 = 16384 bytes
         }
     }
 
     pub fn size_bytes(&self) -> usize {
         match self {
-            RomType::Rom2316 => 2048, // 2KB
-            RomType::Rom2332 => 4096, // 4KB
-            RomType::Rom2364 => 8192, // 8KB
+            RomType::Rom2316 => 2048,   // 2KB
+            RomType::Rom2332 => 4096,   // 4KB
+            RomType::Rom2364 => 8192,   // 8KB
             RomType::Rom23128 => 16384, // 16KB
         }
     }
@@ -229,14 +229,10 @@ impl StmVariant {
 
     pub fn line_enum(&self) -> &str {
         match self {
-            StmVariant::F446RC |
-            StmVariant::F446RE => "F446",
-            StmVariant::F411RC |
-            StmVariant::F411RE => "F411",
+            StmVariant::F446RC | StmVariant::F446RE => "F446",
+            StmVariant::F411RC | StmVariant::F411RE => "F411",
             StmVariant::F405RG => "F405",
-            StmVariant::F401RE |
-            StmVariant::F401RB |
-            StmVariant::F401RC => "F401",
+            StmVariant::F401RE | StmVariant::F401RB | StmVariant::F401RC => "F401",
         }
     }
 

--- a/rust/sdrr-gen/src/config.rs
+++ b/rust/sdrr-gen/src/config.rs
@@ -324,7 +324,7 @@ impl Config {
 
         if !self.hw.supports_multi_rom_sets() {
             return Err(
-                "Multiple ROMs per set is only supported on hardware revision F".to_string(),
+                "Multi-ROM and bank switching sets of ROMs are only supported on hardware revision F".to_string(),
             );
         }
 

--- a/rust/sdrr-gen/src/config.rs
+++ b/rust/sdrr-gen/src/config.rs
@@ -2,11 +2,11 @@
 //
 // MIT License
 
-use sdrr_common::sdrr_types::{CsLogic, RomType, ServeAlg, StmVariant};
 use crate::preprocessor::{RomImage, RomSet};
 use sdrr_common::hardware::HwConfig;
-use std::path::PathBuf;
+use sdrr_common::sdrr_types::{CsLogic, RomType, ServeAlg, StmVariant};
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -49,6 +49,7 @@ pub struct RomConfig {
     pub cs_config: CsConfig,
     pub size_handling: SizeHandling,
     pub set: Option<usize>,
+    pub bank: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -172,24 +173,126 @@ impl Config {
         }
 
         // Validate ROM sets (basic validation that doesn't need ROM images)
-        let mut sets: Vec<usize> = self.roms.iter()
-            .filter_map(|rom| rom.set)
-            .collect();
-        
+        let mut sets: Vec<usize> = self.roms.iter().filter_map(|rom| rom.set).collect();
+
         if !sets.is_empty() {
             // Check if all ROMs have sets specified
             let roms_with_sets = self.roms.iter().filter(|rom| rom.set.is_some()).count();
             if roms_with_sets != self.roms.len() {
                 return Err("When using sets, all ROMs must specify a set number".to_string());
             }
-            
+
             // Sort and check sequential from 0
             sets.sort();
             sets.dedup();
-            
+
             for (i, &set_num) in sets.iter().enumerate() {
                 if set_num != i {
-                    return Err(format!("ROM sets must be numbered sequentially starting from 0. Missing set {}", i));
+                    return Err(format!(
+                        "ROM sets must be numbered sequentially starting from 0. Missing set {}",
+                        i
+                    ));
+                }
+            }
+
+            // Enhanced set validation for banking and multi-ROM modes
+            for &set_id in &sets {
+                let roms_in_set: Vec<_> = self
+                    .roms
+                    .iter()
+                    .filter(|rom| rom.set == Some(set_id))
+                    .collect();
+
+                // Check if this set uses banking
+                let banked_roms: Vec<_> = roms_in_set
+                    .iter()
+                    .filter(|rom| rom.bank.is_some())
+                    .collect();
+
+                let is_banked_set = !banked_roms.is_empty();
+
+                if is_banked_set {
+                    // Banking mode validation
+
+                    // All ROMs in set must have bank specified
+                    if banked_roms.len() != roms_in_set.len() {
+                        return Err(format!(
+                            "Set {}: when using banks, all ROMs in the set must specify a bank number",
+                            set_id
+                        ));
+                    }
+
+                    // Max 4 ROMs for banked sets
+                    if roms_in_set.len() > 4 {
+                        return Err(format!(
+                            "Set {}: banked sets can contain maximum 4 ROMs, found {}",
+                            set_id,
+                            roms_in_set.len()
+                        ));
+                    }
+
+                    // Banks must be sequential from 0
+                    let mut banks: Vec<usize> =
+                        roms_in_set.iter().map(|rom| rom.bank.unwrap()).collect();
+                    banks.sort();
+                    banks.dedup();
+
+                    for (i, &bank_num) in banks.iter().enumerate() {
+                        if bank_num != i {
+                            return Err(format!(
+                                "Set {}: bank numbers must be sequential starting from 0. Missing bank {}",
+                                set_id, i
+                            ));
+                        }
+                    }
+
+                    // All ROMs must have same type
+                    let first_rom_type = &roms_in_set[0].rom_type;
+                    for rom in &roms_in_set[1..] {
+                        if rom.rom_type != *first_rom_type {
+                            return Err(format!(
+                                "Set {}: all ROMs in a banked set must have the same type. Found {} and {}",
+                                set_id,
+                                first_rom_type.name(),
+                                rom.rom_type.name()
+                            ));
+                        }
+                    }
+
+                    // All ROMs must have same CS configuration
+                    let first_cs_config = &roms_in_set[0].cs_config;
+                    for rom in &roms_in_set[1..] {
+                        if rom.cs_config.cs1 != first_cs_config.cs1
+                            || rom.cs_config.cs2 != first_cs_config.cs2
+                            || rom.cs_config.cs3 != first_cs_config.cs3
+                        {
+                            return Err(format!(
+                                "Set {}: all ROMs in a banked set must have the same CS configuration",
+                                set_id
+                            ));
+                        }
+                    }
+                } else {
+                    // Multi-ROM mode validation
+
+                    // Ensure no ROMs have bank specified
+                    for rom in &roms_in_set {
+                        if rom.bank.is_some() {
+                            return Err(format!(
+                                "Set {}: mixed banking modes not allowed - either all ROMs specify bank or none do",
+                                set_id
+                            ));
+                        }
+                    }
+
+                    // Max 3 ROMs for multi-ROM sets
+                    if roms_in_set.len() > 3 {
+                        return Err(format!(
+                            "Set {}: multi-ROM sets can contain maximum 3 ROMs, found {}",
+                            set_id,
+                            roms_in_set.len()
+                        ));
+                    }
                 }
             }
         }
@@ -198,59 +301,90 @@ impl Config {
     }
 
     pub fn create_rom_sets(&self, rom_images: &[RomImage]) -> Result<Vec<RomSet>, String> {
-        // Collect all sets
-        let sets: Vec<usize> = self.roms.iter()
-            .filter_map(|rom| rom.set)
-            .collect();
-        
+        let sets: Vec<usize> = self.roms.iter().filter_map(|rom| rom.set).collect();
+
         if sets.is_empty() {
-            // No sets specified - backward compatibility mode: each ROM gets its own set
-            let rom_sets: Vec<RomSet> = self.roms.iter().zip(rom_images.iter()).enumerate()
-                .map(|(ii, (rom_config, rom_image))| {
-                    RomSet {
-                        id: ii,
-                        roms: vec![RomInSet {
-                            config: rom_config.clone(),
-                            image: rom_image.clone(),
-                            original_index: ii,
-                        }],
-                    }
+            let rom_sets: Vec<RomSet> = self
+                .roms
+                .iter()
+                .zip(rom_images.iter())
+                .enumerate()
+                .map(|(ii, (rom_config, rom_image))| RomSet {
+                    id: ii,
+                    roms: vec![RomInSet {
+                        config: rom_config.clone(),
+                        image: rom_image.clone(),
+                        original_index: ii,
+                    }],
+                    is_banked: false,
                 })
                 .collect();
             return Ok(rom_sets);
         }
 
         if !self.hw.supports_multi_rom_sets() {
-            return Err("Multiple ROMs per set is only supported on hardware revision F".to_string());
+            return Err(
+                "Multiple ROMs per set is only supported on hardware revision F".to_string(),
+            );
         }
 
-        // Create ROM sets map
+        let mut unique_sets: Vec<usize> = sets.clone();
+        unique_sets.sort();
+        unique_sets.dedup();
+
         let mut rom_sets_map = BTreeMap::new();
-        
-        for (original_index, (rom_config, rom_image)) in self.roms.iter().zip(rom_images.iter()).enumerate() {
-            let set_id = rom_config.set.unwrap(); // We know all ROMs have sets at this point
-            let roms_in_set = rom_sets_map.entry(set_id).or_insert_with(Vec::new);
-            
 
-            // CS lines: 10 (standard), 14 (X1), 15 (X2) 
-            // Note: X1 and X2 pins only available on hardware revision F
-            let index = roms_in_set.len();
-            if index >= 3 {
-                return Err(format!("Set {} has more than the maximum 3 ROMs", set_id));
+        for &set_id in &unique_sets {
+            let roms_in_set: Vec<_> = self
+                .roms
+                .iter()
+                .zip(rom_images.iter())
+                .enumerate()
+                .filter(|(_, (rom_config, _))| rom_config.set == Some(set_id))
+                .collect();
+
+            let is_banked = roms_in_set
+                .iter()
+                .any(|(_, (rom_config, _))| rom_config.bank.is_some());
+
+            let mut rom_set_entries = Vec::new();
+
+            if is_banked {
+                let mut banked_roms: Vec<_> = roms_in_set.into_iter().collect();
+                banked_roms.sort_by_key(|(_, (rom_config, _))| rom_config.bank.unwrap());
+
+                for (original_index, (rom_config, rom_image)) in banked_roms {
+                    rom_set_entries.push(RomInSet {
+                        config: rom_config.clone(),
+                        image: rom_image.clone(),
+                        original_index,
+                    });
+                }
+            } else {
+                for (original_index, (rom_config, rom_image)) in roms_in_set {
+                    rom_set_entries.push(RomInSet {
+                        config: rom_config.clone(),
+                        image: rom_image.clone(),
+                        original_index,
+                    });
+                }
             }
-            
-            roms_in_set.push(RomInSet {
-                config: rom_config.clone(),
-                image: rom_image.clone(),
-                original_index,
-            });
+
+            rom_sets_map.insert(
+                set_id,
+                RomSet {
+                    id: set_id,
+                    roms: rom_set_entries,
+                    is_banked,
+                },
+            );
         }
-        
-        // Convert to final ROM sets vector
-        let rom_sets: Vec<RomSet> = rom_sets_map.into_iter()
-            .map(|(id, roms)| RomSet { id, roms })
+
+        let rom_sets: Vec<RomSet> = unique_sets
+            .into_iter()
+            .map(|set_id| rom_sets_map.remove(&set_id).unwrap())
             .collect();
-            
+
         Ok(rom_sets)
     }
 }

--- a/rust/sdrr-gen/src/generator.rs
+++ b/rust/sdrr-gen/src/generator.rs
@@ -281,22 +281,24 @@ fn generate_roms_implementation_file(config: &Config, rom_sets: &[RomSet]) -> Re
                     "All ROMs in a multi-ROM set must have the same CS1 configuration"
                 ));
             }
-
-            // Check that every ROM in this set has CS2 and CS3 ignored.
-            if rom_set.roms.iter().any(|rom| {
-                rom.config
-                    .cs_config
-                    .cs2
-                    .is_some_and(|cs| cs != CsLogic::Ignore)
-                    || rom
-                        .config
+            
+            if !rom_set.is_banked {
+                // Check that every ROM in this set has CS2 and CS3 ignored.
+                if rom_set.roms.iter().any(|rom| {
+                    rom.config
                         .cs_config
-                        .cs3
+                        .cs2
                         .is_some_and(|cs| cs != CsLogic::Ignore)
-            }) {
-                return Err(anyhow::anyhow!(
-                    "All ROMs in a multi-ROM set must have CS2 and CS3 ignored or not present"
-                ));
+                        || rom
+                            .config
+                            .cs_config
+                            .cs3
+                            .is_some_and(|cs| cs != CsLogic::Ignore)
+                }) {
+                    return Err(anyhow::anyhow!(
+                        "All ROMs in a multi-ROM set must have CS2 and CS3 ignored or not present"
+                    ));
+                }
             }
 
             // Use the CS1 state from any ROM image, as they must be the same

--- a/rust/sdrr-gen/src/preprocessor.rs
+++ b/rust/sdrr-gen/src/preprocessor.rs
@@ -2,10 +2,10 @@
 //
 // MIT License
 
-use crate::config::{SizeHandling, RomInSet};
-use sdrr_common::sdrr_types::{RomType, CsLogic};
-use sdrr_common::hardware::HwConfig;
+use crate::config::{RomInSet, SizeHandling};
 use anyhow::{Context, Result};
+use sdrr_common::hardware::HwConfig;
+use sdrr_common::sdrr_types::{CsLogic, RomType};
 use std::fs;
 use std::path::Path;
 
@@ -82,7 +82,7 @@ impl RomImage {
     pub fn transform_address(
         &self,
         address: usize,
-        phys_pin_to_addr_map: &[Option<usize>]
+        phys_pin_to_addr_map: &[Option<usize>],
     ) -> usize {
         // Start with 0 result
         let mut result = 0;
@@ -147,7 +147,12 @@ impl RomImage {
     /// This ensures that when the hardware reads from a certain address
     /// through its GPIO pins, it gets the correct byte value with bits
     /// arranged according to its data pin connections.
-    pub fn get_byte(&self, address: usize, phys_pin_to_addr_map: &[Option<usize>], phys_pin_to_data_map: &[usize]) -> u8 {
+    pub fn get_byte(
+        &self,
+        address: usize,
+        phys_pin_to_addr_map: &[Option<usize>],
+        phys_pin_to_data_map: &[usize],
+    ) -> u8 {
         // We have been passed a physical address based on the hardware pins,
         // so we need to transform it to a logical address based on the ROM
         // image.
@@ -178,21 +183,41 @@ impl RomImage {
 pub struct RomSet {
     pub id: usize,
     pub roms: Vec<RomInSet>,
+    pub is_banked: bool,
 }
 
 impl RomSet {
     pub fn get_byte(&self, address: usize, hw: &HwConfig) -> u8 {
         let phys_pin_to_data_map = hw.get_phys_pin_to_data_map();
 
-            // Backward compatibility: single ROM uses existing behavior
-        if self.roms.len() == 1 {
-            let num_addr_lines = self.roms[0].config.rom_type.num_addr_lines();
+        // Hard-coded assumption that X1/X2 (if present) are pins 14/15 for
+        // single ROM sets and banked ROM sets.
+        if (self.roms.len() == 1) || (self.is_banked) {
+            let (rom_index, masked_address) = if !self.is_banked {
+                assert!(address < 16384, "Address out of bounds for single ROM set");
+                (0, address)
+            } else {
+                // Banked mode: use top 2 bits (14,15) to select ROM
+                assert!(address < 65536, "Address out of bounds for banked ROM set");
+                let bank = (address >> 14) & 3; // Get bank
+                let rom_index = bank % self.roms.len(); // Wrap around
+                let masked_address = address & 0x3FFF; // Remove top 2 bits
+                (rom_index, masked_address)
+            };
+
+            let num_addr_lines = self.roms[rom_index].config.rom_type.num_addr_lines();
             let phys_pin_to_addr_map = hw.get_phys_pin_to_addr_map(num_addr_lines);
 
-            return self.roms[0].image.get_byte(address, &phys_pin_to_addr_map, &phys_pin_to_data_map);
+            return self.roms[rom_index].image.get_byte(
+                masked_address,
+                &phys_pin_to_addr_map,
+                &phys_pin_to_data_map,
+            );
         }
 
-        // Multiple ROMs: check CS line states to select responding ROM
+        // Multiple ROMs: check CS line states to select responding ROM.  This
+        // code can handle any X1/X2 positions - but the above can't.
+        assert!(address < 65536, "Address out of bounds for multi-ROM set");
         for (index, rom_in_set) in self.roms.iter().enumerate() {
             // Get the physical addr and data pin mappings.  We have to
             // retrieve this for each ROM in the set, as each ROM may be
@@ -218,7 +243,7 @@ impl RomSet {
             }
 
             let cs_active = is_pin_active(pins_active_high, address, cs_pin);
-            
+
             if cs_active {
                 // Verify exactly one CS pin is active
                 let cs1_pin = hw.pin_cs1(&rom_in_set.config.rom_type);
@@ -226,23 +251,22 @@ impl RomSet {
                 let x2_pin = hw.pin_x2();
 
                 let cs1_is_active = is_pin_active(pins_active_high, address, cs1_pin);
-                let x1_is_active = is_pin_active(
-                    pins_active_high,
-                    address,
-                    x1_pin
-                );
-                let x2_is_active = is_pin_active(
-                    pins_active_high,
-                    address,
-                    x2_pin
-                );
+                let x1_is_active = is_pin_active(pins_active_high, address, x1_pin);
+                let x2_is_active = is_pin_active(pins_active_high, address, x2_pin);
 
-                let active_count = [cs1_is_active, x1_is_active, x2_is_active].iter().filter(|&&x| x).count();
-                
+                let active_count = [cs1_is_active, x1_is_active, x2_is_active]
+                    .iter()
+                    .filter(|&&x| x)
+                    .count();
+
                 // Only return the byte for a single CS active, otherwise
                 // it'll get 0xAA
                 if active_count == 1 && self.check_rom_cs_requirements(rom_in_set, address, hw) {
-                    return rom_in_set.image.get_byte(address, &phys_pin_to_addr_map, &phys_pin_to_data_map);
+                    return rom_in_set.image.get_byte(
+                        address,
+                        &phys_pin_to_addr_map,
+                        &phys_pin_to_data_map,
+                    );
                 }
             }
         }
@@ -250,55 +274,68 @@ impl RomSet {
         RomImage::transform_byte(0xAA, &phys_pin_to_data_map) // No ROM selected
     }
 
-    fn check_rom_cs_requirements(&self, rom_in_set: &RomInSet, address: usize, hw: &HwConfig) -> bool {
+    fn check_rom_cs_requirements(
+        &self,
+        rom_in_set: &RomInSet,
+        address: usize,
+        hw: &HwConfig,
+    ) -> bool {
         let cs_config = &rom_in_set.config.cs_config;
         let rom_type = &rom_in_set.config.rom_type;
-        
+
         // Check CS2 if specified
         if let Some(cs2_logic) = cs_config.cs2 {
             match cs2_logic {
                 CsLogic::Ignore => {
                     // CS2 state doesn't matter
-                },
+                }
                 CsLogic::ActiveLow => {
                     let cs2_pin = hw.pin_cs2(rom_type);
                     let cs2_active = (address & (1 << cs2_pin)) == 0;
-                    if !cs2_active { return false; }
-                },
+                    if !cs2_active {
+                        return false;
+                    }
+                }
                 CsLogic::ActiveHigh => {
                     let cs2_pin = hw.pin_cs2(rom_type);
                     let cs2_active = (address & (1 << cs2_pin)) != 0;
-                    if cs2_active { return false; }
-                },
+                    if cs2_active {
+                        return false;
+                    }
+                }
             }
         }
-        
+
         // Check CS3 if specified
         if let Some(cs3_logic) = cs_config.cs3 {
             match cs3_logic {
                 CsLogic::Ignore => {
                     // CS3 state doesn't matter
-                },
+                }
                 CsLogic::ActiveLow => {
                     let cs3_pin = hw.pin_cs3(rom_type);
                     let cs3_active = (address & (1 << cs3_pin)) == 0;
-                    if !cs3_active { return false; }
-                },
+                    if !cs3_active {
+                        return false;
+                    }
+                }
                 CsLogic::ActiveHigh => {
                     let cs3_pin = hw.pin_cs3(rom_type);
                     let cs3_active = (address & (1 << cs3_pin)) != 0;
-                    if cs3_active { return false; }
-                },
+                    if cs3_active {
+                        return false;
+                    }
+                }
             }
         }
-        
+
         true
     }
 
     #[allow(dead_code)]
     fn mask_cs_selection_bits(&self, address: usize, rom_type: &RomType, hw: HwConfig) -> usize {
         let mut masked_address = address;
-        
+
         // Remove the CS selection bits - only mask bits that exist on this hardware
         masked_address &= !(1 << hw.pin_cs1(rom_type));
 
@@ -310,24 +347,24 @@ impl RomSet {
             masked_address &= !(1 << x1);
             masked_address &= !(1 << x2);
         }
-        
+
         // Remove CS2/CS3 bits based on ROM type
         match rom_type {
             RomType::Rom2332 => {
                 masked_address &= !(1 << hw.pin_cs2(rom_type));
-            },
+            }
             RomType::Rom2316 => {
                 masked_address &= !(1 << hw.pin_cs2(rom_type));
                 masked_address &= !(1 << hw.pin_cs3(rom_type));
-            },
+            }
             RomType::Rom2364 => {
                 // 2364 only uses CS1, no additional bits to remove
-            },
+            }
             RomType::Rom23128 => {
                 // No additional bits to remove
-            },
+            }
         }
-        
+
         // Ensure address fits within ROM size
         masked_address & ((1 << 13) - 1) // Mask to 13 bits max (8KB)
     }

--- a/rust/sdrr-info/src/args.rs
+++ b/rust/sdrr-info/src/args.rs
@@ -84,8 +84,8 @@ enum Commands {
     /// address bus, using a non-mangled address.  Use this to detect
     /// what byte the STM32F4 will output on the data lines in
     /// response to a particular address on the address bus.  This
-    /// option requires CS line states, including, for multi-rom sets,
-    /// the X1 and X2 pins.
+    /// option requires CS line states, including, for multi-rom and
+    /// bank switched sets, the X1 and X2 pins.
     ///
     /// This option allows a single byte or range of bytes to be
     /// looked up.  The output can be output as text (2 byte hex
@@ -124,11 +124,10 @@ enum Commands {
         /// CS3 line state (0 or 1) - valid for 2316 ROMs only
         #[arg(long, value_parser = parse_cs_line)]
         cs3: Option<u8>,
-        /// X1 line state (0 or 1) - valid for multi-ROM sets only
+        /// X1 line state (0 or 1) - valid for multi-ROM/bank switched sets only
         #[arg(long, value_parser = parse_cs_line)]
         x1: Option<u8>,
-        /// X2 line state (0 or 1) - valid for multi-ROM sets only
-        /// #[arg(long, value_parser = parse_cs_line)]
+        /// X2 line state (0 or 1) - valid for multi-ROM/bank switched sets only
         #[arg(long, value_parser = parse_cs_line)]
         x2: Option<u8>,
         /// Output mangled data byte(s)

--- a/rust/sdrr-info/src/load.rs
+++ b/rust/sdrr-info/src/load.rs
@@ -4,11 +4,11 @@
 
 use anyhow::Result;
 use goblin::elf::Elf;
-use std::path::Path;
 use std::fs;
+use std::path::Path;
 
-use sdrr_fw_parser::{SdrrInfo, SdrrFileType};
 use crate::{SDRR_INFO_OFFSET, STM32F4_FLASH_BASE};
+use sdrr_fw_parser::{SdrrFileType, SdrrInfo};
 
 pub fn load_sdrr_firmware<P: AsRef<Path>>(path: P) -> Result<SdrrInfo> {
     let firmware_data = fs::read(path)?;

--- a/rust/sdrr-info/src/main.rs
+++ b/rust/sdrr-info/src/main.rs
@@ -42,7 +42,7 @@ use std::path::Path;
 
 use args::{Args, Command, parse_args};
 use load::load_sdrr_firmware;
-use sdrr_fw_parser::{SdrrInfo, SdrrStmPort};
+use sdrr_fw_parser::{SdrrInfo, SdrrStmPort, SdrrServe};
 use utils::add_commas;
 
 // SDRR info structure offset in firmware binary
@@ -277,7 +277,7 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
 
     if args.detail {
         println!();
-        println!("ROM Details: {}", info.rom_set_count);
+        println!("ROM Details:");
         println!("--------------");
 
         for (ii, rom_set) in info.rom_sets.iter().enumerate() {
@@ -285,20 +285,28 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
                 println!("-----------");
             }
             println!("ROM Set: {}", ii);
-            println!("  Size: {} bytes", rom_set.size);
+            let set_type = if rom_set.serve == SdrrServe::AddrOnAnyCs {
+                "Multi-ROM socket"
+            } else if rom_set.rom_count > 1 {
+                "Dynamic bank switching"
+            } else {
+                "Single ROM image"
+            };
+            println!("  Set type:      {}", set_type);
+            println!("  Size:          {} bytes", rom_set.size);
             println!("  ROM Count:     {}", rom_set.rom_count);
             println!("  Algorithm:     {}", rom_set.serve);
             println!("  Multi-ROM CS1: {}", rom_set.multi_rom_cs1_state);
 
             for (jj, rom) in rom_set.roms.iter().enumerate() {
                 println!("  ROM: {}", jj);
-                println!("    Type:      {}", rom.rom_type);
+                println!("    Type:        {}", rom.rom_type);
                 println!(
-                    "    Name:      {}",
+                    "    Name:        {}",
                     rom.filename.as_deref().unwrap_or("<not present>")
                 );
                 println!(
-                    "    CS States: {}/{}/{}",
+                    "    CS States:   {}/{}/{}",
                     rom.cs1_state, rom.cs2_state, rom.cs3_state
                 );
             }

--- a/rust/sdrr-info/src/main.rs
+++ b/rust/sdrr-info/src/main.rs
@@ -29,20 +29,20 @@ pub const SDRR_VERSION_MINOR: u16 = 2;
 pub const SDRR_VERSION_PATCH: u16 = 1;
 
 // Modules
-mod load;
 mod args;
+mod load;
 mod utils;
 
 // External crates
 use anyhow::Result;
+use chrono::{DateTime, Local};
+use std::fs::metadata;
 use std::io::Write;
 use std::path::Path;
-use std::fs::metadata;
-use chrono::{DateTime, Local};
 
-use sdrr_fw_parser::{SdrrInfo, SdrrStmPort};
-use load::load_sdrr_firmware;
 use args::{Args, Command, parse_args};
+use load::load_sdrr_firmware;
+use sdrr_fw_parser::{SdrrInfo, SdrrStmPort};
 use utils::add_commas;
 
 // SDRR info structure offset in firmware binary
@@ -73,7 +73,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(e) => {
             print_header();
             eprintln!("Error loading firmware");
-            eprintln!("Did you supply an SDRR v{}.{}.{} or later .elf or .bin file?", SDRR_VERSION_MAJOR, SDRR_VERSION_MINOR, SDRR_VERSION_PATCH);
+            eprintln!(
+                "Did you supply an SDRR v{}.{}.{} or later .elf or .bin file?",
+                SDRR_VERSION_MAJOR, SDRR_VERSION_MINOR, SDRR_VERSION_PATCH
+            );
             eprintln!("Detailed error: {}", e);
             std::process::exit(1);
         }
@@ -101,7 +104,8 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
 
     println!("Core Firmware Properties");
     println!("------------------------");
-    println!("File name:     {}", 
+    println!(
+        "File name:     {}",
         Path::new(&args.firmware)
             .file_name()
             .map(|n| n.to_string_lossy())
@@ -116,7 +120,11 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
         .unwrap_or_else(|_| "error".to_string());
     println!("File modified: {}", modified_str);
     println!("File type:     {}", info.file_type);
-    println!("File size:     {} bytes ({}KB)", add_commas(info.file_size as u64), (info.file_size + 1023) / 1024);
+    println!(
+        "File size:     {} bytes ({}KB)",
+        add_commas(info.file_size as u64),
+        (info.file_size + 1023) / 1024
+    );
     println!(
         "Version:       {}.{}.{} (build {})",
         info.major_version, info.minor_version, info.patch_version, info.build_number
@@ -163,20 +171,28 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
         "false"
     };
     println!("MCO enabled:      {}", mco);
-    println!("Boot config:      0x{:2X}{:2X}{:2X}{:2X} - Reserved, should be 0xFFFFFFFF",
-        info.boot_config[0], info.boot_config[1], info.boot_config[2], info.boot_config[3]);
+    println!(
+        "Boot config:      0x{:2X}{:2X}{:2X}{:2X} - Reserved, should be 0xFFFFFFFF",
+        info.boot_config[0], info.boot_config[1], info.boot_config[2], info.boot_config[3]
+    );
     println!();
 
     if args.detail {
         let pins = &info.pins;
         println!("Pin Configuration");
         println!("-----------------");
-        
+
         println!();
         println!("Data pin mapping:");
         for (ii, &pin) in pins.data.iter().enumerate() {
             if pin != 0xFF {
-                println!("  D{}: {}P{}{}", ii, if ii < 10 { " " } else { "" }, pins.data_port, pin);
+                println!(
+                    "  D{}: {}P{}{}",
+                    ii,
+                    if ii < 10 { " " } else { "" },
+                    pins.data_port,
+                    pin
+                );
             }
         }
 
@@ -184,29 +200,63 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
         println!("Address pin mapping:");
         for (ii, &pin) in pins.addr.iter().enumerate() {
             if pin != 0xFF {
-                println!("  A{}: {}P{}{}", ii, if ii < 10 { " " } else { "" }, pins.addr_port, pin);
+                println!(
+                    "  A{}: {}P{}{}",
+                    ii,
+                    if ii < 10 { " " } else { "" },
+                    pins.addr_port,
+                    pin
+                );
             }
         }
-        
+
         println!();
         println!("Chip select pins:");
-        if pins.cs1_2364 != 0xFF { println!("  2364 CS1: P{}{}", pins.cs_port, pins.cs1_2364); }
-        if pins.cs1_2332 != 0xFF { println!("  2332 CS1: P{}{}", pins.cs_port, pins.cs1_2332); }
-        if pins.cs2_2332 != 0xFF { println!("  2332 CS2: P{}{}", pins.cs_port, pins.cs2_2332); }
-        if pins.cs1_2316 != 0xFF { println!("  2316 CS1: P{}{}", pins.cs_port, pins.cs1_2316); }
-        if pins.cs2_2316 != 0xFF { println!("  2316 CS2: P{}{}", pins.cs_port, pins.cs2_2316); }
-        if pins.cs3_2316 != 0xFF { println!("  2316 CS3: P{}{}", pins.cs_port, pins.cs3_2316); }
-        if pins.ce_23128 != 0xFF { println!("  23128 CE: P{}{}", pins.cs_port, pins.ce_23128); }
-        if pins.oe_23128 != 0xFF { println!("  23128 OE: P{}{}", pins.cs_port, pins.oe_23128); }
-        if pins.x1 != 0xFF { println!("  Multi X1: P{}{}", pins.cs_port, pins.x1); }
-        if pins.x2 != 0xFF { println!("  Multi X2: P{}{}", pins.cs_port, pins.x2); }
+        if pins.cs1_2364 != 0xFF {
+            println!("  2364 CS1: P{}{}", pins.cs_port, pins.cs1_2364);
+        }
+        if pins.cs1_2332 != 0xFF {
+            println!("  2332 CS1: P{}{}", pins.cs_port, pins.cs1_2332);
+        }
+        if pins.cs2_2332 != 0xFF {
+            println!("  2332 CS2: P{}{}", pins.cs_port, pins.cs2_2332);
+        }
+        if pins.cs1_2316 != 0xFF {
+            println!("  2316 CS1: P{}{}", pins.cs_port, pins.cs1_2316);
+        }
+        if pins.cs2_2316 != 0xFF {
+            println!("  2316 CS2: P{}{}", pins.cs_port, pins.cs2_2316);
+        }
+        if pins.cs3_2316 != 0xFF {
+            println!("  2316 CS3: P{}{}", pins.cs_port, pins.cs3_2316);
+        }
+        if pins.ce_23128 != 0xFF {
+            println!("  23128 CE: P{}{}", pins.cs_port, pins.ce_23128);
+        }
+        if pins.oe_23128 != 0xFF {
+            println!("  23128 OE: P{}{}", pins.cs_port, pins.oe_23128);
+        }
+        if pins.x1 != 0xFF {
+            println!("  Multi X1: P{}{}", pins.cs_port, pins.x1);
+        }
+        if pins.x2 != 0xFF {
+            println!("  Multi X2: P{}{}", pins.cs_port, pins.x2);
+        }
 
         println!();
         println!("Image select pins:");
-        if pins.sel0 != 0xFF { println!("  SEL0: P{}{}", pins.sel_port, pins.sel0); }
-        if pins.sel1 != 0xFF { println!("  SEL1: P{}{}", pins.sel_port, pins.sel1); }
-        if pins.sel2 != 0xFF { println!("  SEL2: P{}{}", pins.sel_port, pins.sel2); }
-        if pins.sel3 != 0xFF { println!("  SEL3: P{}{}", pins.sel_port, pins.sel3); }
+        if pins.sel0 != 0xFF {
+            println!("  SEL0: P{}{}", pins.sel_port, pins.sel0);
+        }
+        if pins.sel1 != 0xFF {
+            println!("  SEL1: P{}{}", pins.sel_port, pins.sel1);
+        }
+        if pins.sel2 != 0xFF {
+            println!("  SEL2: P{}{}", pins.sel_port, pins.sel2);
+        }
+        if pins.sel3 != 0xFF {
+            println!("  SEL3: P{}{}", pins.sel_port, pins.sel3);
+        }
 
         println!();
         println!("Status LED pin:");
@@ -222,8 +272,7 @@ fn print_sdrr_info(info: &SdrrInfo, args: &Args) {
     println!("-------------");
     println!("Total sets: {}", info.rom_set_count);
     // Count up total number of ROM images across all sets
-    let total_roms: usize = info.rom_sets.iter().map(|set| set
-        .roms.len()).sum();
+    let total_roms: usize = info.rom_sets.iter().map(|set| set.roms.len()).sum();
     println!("Total ROMs: {}", total_roms);
 
     if args.detail {
@@ -320,8 +369,15 @@ fn lookup_raw(info: &SdrrInfo, args: &Args) {
         .output_mangled
         .expect("Internal error: output_mangled is required");
 
-    if let Err(e) = lookup_byte_at_address(info, args.detail, set, addr, addr, output_mangled, "Mangled address")
-    {
+    if let Err(e) = lookup_byte_at_address(
+        info,
+        args.detail,
+        set,
+        addr,
+        addr,
+        output_mangled,
+        "Mangled address",
+    ) {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
@@ -366,20 +422,14 @@ fn lookup_range(
         ));
     }
     if cs2.is_some() && !rom_type.supports_cs2() {
-        return Err(format!(
-            "ROM type {} does not support CS2 line",
-            rom_type
-        ));
+        return Err(format!("ROM type {} does not support CS2 line", rom_type));
     }
     if cs3.is_some() && !rom_type.supports_cs3() {
-        return Err(format!(
-            "ROM type {} does not support CS3 line",
-            rom_type
-        ));
+        return Err(format!("ROM type {} does not support CS3 line", rom_type));
     }
     if (x1.is_some() || x2.is_some()) && info.rom_sets[set as usize].roms.len() < 2 {
         return Err("Multi-ROM X1/X2 lines can only be used with multi-ROM sets".to_string());
-    } 
+    }
 
     if output_binary {
         // Collect bytes for binary output
@@ -425,7 +475,7 @@ fn lookup_range(
             if byte_pos % 16 == 0 {
                 print!("{:04X}: ", addr);
             }
-            
+
             // Print the byte
             print!("{:02X}", output_byte);
 
@@ -501,7 +551,7 @@ fn lookup(info: &SdrrInfo, args: &Args) {
             Err(e) => {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
-            },
+            }
         };
 
         if let Err(e) = lookup_byte_at_address(

--- a/rust/sdrr-info/src/utils.rs
+++ b/rust/sdrr-info/src/utils.rs
@@ -6,7 +6,7 @@ pub fn add_commas(n: u64) -> String {
     let s = n.to_string();
     let chars: Vec<char> = s.chars().collect();
     let mut result = String::new();
-    
+
     for (i, &c) in chars.iter().enumerate() {
         if i > 0 && (chars.len() - i) % 3 == 0 {
             result.push(',');

--- a/sdrr/src/rom_impl.c
+++ b/sdrr/src/rom_impl.c
@@ -98,8 +98,7 @@ void __attribute__((section(".main_loop"), used)) main_loop(const sdrr_rom_set_t
 
     // Warn if serve mode is incorrectly set for multiple ROM images
     if ((set->rom_count > 1) && (serve_mode != SERVE_ADDR_ON_ANY_CS)) {
-        ROM_IMPL_LOG("!!! Mutliple ROM images - wrong serve mode - rectifying");
-        serve_mode = SERVE_ADDR_ON_ANY_CS;
+        ROM_IMPL_LOG("Must be serving bank switched images");
     } else if ((set->rom_count == 1) && (serve_mode == SERVE_ADDR_ON_ANY_CS)) {
         ROM_IMPL_LOG("!!! Single ROM image - wrong serve mode - defaulting");
         serve_mode = SERVE_TWO_CS_ONE_ADDR;
@@ -226,7 +225,7 @@ void __attribute__((section(".main_loop"), used)) main_loop(const sdrr_rom_set_t
     // Port C for address and CS lines - set all pins as inputs
     GPIOC_MODER = 0;  // Set all pins as inputs
     uint32_t gpioc_pupdr;
-    if (set->rom_count == 1) {
+    if (serve_mode != SERVE_ADDR_ON_ANY_CS) {
         // Set pull-downs on PC14/15 only, so RAM lookup only takes 16KB.
         // We checked the address lines are lines 0-13 above, and in sdrr-gen
         // so this is reasonable.

--- a/test/src/check-roms.c
+++ b/test/src/check-roms.c
@@ -33,7 +33,9 @@ int validate_all_rom_sets(json_config_t *json_config, loaded_rom_t *loaded_roms,
         // switched sets are handled in the else.
         if (num_roms == 1) {
             int loaded_rom_idx = overall_rom_idx;
-            printf("- Testing ROM %d in set %d\n  - Type: %s, Name: %s\n", 0, set_idx, configs[overall_rom_idx].type, configs[loaded_rom_idx].filename);
+            printf("- Single ROM set\n");
+            printf("  - Testing ROM %d in set %d\n", 0, set_idx);
+            printf("    - Type: %s, Name: %s\n", configs[overall_rom_idx].type, configs[loaded_rom_idx].filename);
 
             // Single ROM: test both CS=0 and CS=1 against expected value.
             // 2332/2316 ROMs are tested by virtue of their extra CS line(s)
@@ -73,6 +75,11 @@ int validate_all_rom_sets(json_config_t *json_config, loaded_rom_t *loaded_roms,
             }
             overall_rom_idx++;
         } else {
+            if (serve == SERVE_ADDR_ON_ANY_CS) {
+                printf("- Multi-ROM set\n");
+            }  else {
+                printf("- Bank switched set\n");
+            }
             // Multi-ROM/bank switched set: test all 8 CS combinations
             int cs_combinations[8][3] = {
                 // X1 is set to 1 before X2 so the output is more logic
@@ -122,13 +129,13 @@ int validate_all_rom_sets(json_config_t *json_config, loaded_rom_t *loaded_roms,
                 if (active_rom >= 0) {
                     int loaded_rom_idx = overall_rom_idx + active_rom;
                     if (loaded_rom_idx < count) {
-                        printf("- ROM %d in set %d - CS1=%d, X1=%d, X2=%d", active_rom, set_idx, cs1, x1, x2);
-                        printf("  - Type: %s, Name: %s\n", configs[loaded_rom_idx].type, configs[loaded_rom_idx].filename);
+                        printf("  - ROM %d in set %d - CS1=%d, X1=%d, X2=%d\n", active_rom, set_idx, cs1, x1, x2);
+                        printf("    - Type: %s, Name: %s\n", configs[loaded_rom_idx].type, configs[loaded_rom_idx].filename);
                     } else {
-                        printf("- ROM %d in set %d (ERROR: out of bounds)\n", active_rom, set_idx);
+                        printf("  - ROM %d in set %d (ERROR: out of bounds)\n", active_rom, set_idx);
                     }
                 } else {
-                    printf("- Testing blank section CS1=%d, X1=%d, X2=%d\n", cs1, x1, x2);
+                    printf("  - Testing blank section CS1=%d, X1=%d, X2=%d\n", cs1, x1, x2);
                 }
                 
                 // Test all addresses for this combination


### PR DESCRIPTION
X1/X2 pins (HW rev F onwards) can now be used to support dynamic bank switching of ROM images - that is just change a jumper and a new ROM will instantly start being served.  Cannot be used at the same time as serving multiple ROM socket simultaneously.

Also included 1541 upper ROM bank config, and VIC-20 and C64 char rom bank configs.